### PR TITLE
telephony: Also override nw mode on creation of phone objects.

### DIFF
--- a/src/java/com/android/internal/telephony/PhoneFactory.java
+++ b/src/java/com/android/internal/telephony/PhoneFactory.java
@@ -233,6 +233,14 @@ public class PhoneFactory {
                 // because ImsService might need it when it is being opened.
                 for (int i = 0; i < numPhones; i++) {
                     sProxyPhones[i].startMonitoringImsService();
+
+                    // Get users NW type, let it override if its not the default NW mode (-1)
+                    int userNwType = SubscriptionController.getInstance().getUserNwMode(
+                            sProxyPhones[i].getSubId());
+                    if (userNwType != SubscriptionManager.DEFAULT_NW_MODE
+                            && userNwType != networkModes[i]) {
+                        sProxyPhones[i].setPreferredNetworkType(userNwType, null);
+                    }
                 }
             }
         }


### PR DESCRIPTION
  The CAF change @ 8ad9463f7e828afc7a5c2140905db6d50c2beea3 allows
  overriding of the preferred nw mode at the creation of the phone
  object based upon the phone id. Since we abstract this to another
  layer where we have user preferred nw type, we need to override this
  as well.

Change-Id: Id65c095584aba97112a3318cc922d7e0107c12da
