### PR TITLE
telephony: Fix persistence of automatic network selection

### DIFF
--- a/src/java/com/android/internal/telephony/PhoneBase.java
+++ b/src/java/com/android/internal/telephony/PhoneBase.java
@@ -1063,6 +1063,7 @@ public abstract class PhoneBase extends Handler implements Phone {
             handleSetSelectNetwork(ar);
         }
 
+        updateSavedNetworkOperator(nsm);
     }
 
     @Override


### PR DESCRIPTION
Somewhere we mismerged something and lost this rather important line
of code which will actually save the fact that we selected automatic
network selection.

Change-Id: I0597739b0f0dcabf6c54c5b2b2c4dc390d6b1971
