### PR TITLE
Do not disable permanently enabled carrier apps

### DIFF
--- a/src/java/com/android/internal/telephony/CarrierAppUtils.java
+++ b/src/java/com/android/internal/telephony/CarrierAppUtils.java
@@ -87,11 +87,22 @@ public final class CarrierAppUtils {
             return;
         }
 
+        HashSet<String> enabledCarrierAppsSet = new HashSet<>(systemCarrierAppsEnabled.length);
+        for (String packageName : systemCarrierAppsEnabled) {
+            enabledCarrierAppsSet.add(packageName);
+        }
+
         List<String> enabledCarrierPackages = new ArrayList<>();
 
         try {
             for (ApplicationInfo ai : candidates) {
                 String packageName = ai.packageName;
+
+                // Enabled carrier apps are already enabled, so continue
+                if (enabledCarrierAppsSet.contains(ai.packageName)) {
+                    continue;
+                }
+
                 boolean hasPrivileges =
                         telephonyManager.checkCarrierPrivilegesForPackageAnyPhone(packageName) ==
                                 TelephonyManager.CARRIER_PRIVILEGE_STATUS_HAS_ACCESS;


### PR DESCRIPTION
Fix a bug where packages listed in the permanently enabled array would
be treated as non privileged and consequently disabled.

Part of CYNGNOS-1650.

Change-Id: I14758bb83999d2bf9c49c642343863fd2e8e8611
