### PR TITLE
GsmMmiCode: Fix USSD NPE

### DIFF
--- a/src/java/com/android/internal/telephony/gsm/GsmMmiCode.java
+++ b/src/java/com/android/internal/telephony/gsm/GsmMmiCode.java
@@ -1122,7 +1122,8 @@ public final class GsmMmiCode extends Handler implements MmiCode {
                 if (ar.exception != null) {
                     mState = State.FAILED;
                     // suppress error pop-up for single dialed digits
-                    if (mDialingNumber.length() == SINGLE_DIGIT_DIALED) {
+                    if (mDialingNumber != null &&
+                                mDialingNumber.length() == SINGLE_DIGIT_DIALED) {
                         Log.w(
                             LOG_TAG,
                             mContext.getText(com.android.internal.R.string.mmiError).toString()


### PR DESCRIPTION
I83599c6556dec40faa74944c1fe13568b2b634fc trigger NPE on MSIM
device.

Change-Id: Ic3e5a20b101f03da74223e9a62ce459d8c006738
